### PR TITLE
Add document type validation to document uploads

### DIFF
--- a/backend/services/document_service/application/domain/document_job.py
+++ b/backend/services/document_service/application/domain/document_job.py
@@ -7,10 +7,22 @@ from pydantic import BaseModel, Field
 
 
 class ProcessingStatus(str, Enum):
-    PENDING = "PENDING"
-    PROCESSING = "PROCESSING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
+    PENDING = "pendente"
+    PROCESSING = "processando"
+    COMPLETED = "concluido"
+    FAILED = "falhou"
+
+
+class DocumentType(str, Enum):
+    NOTA_FISCAL_EMITIDA = "NOTA_FISCAL_EMITIDA"
+    NOTA_FISCAL_RECEBIDA = "NOTA_FISCAL_RECEBIDA"
+    INFORME_BANCARIO = "INFORME_BANCARIO"
+    DESPESA_DEDUTIVEL = "DESPESA_DEDUTIVEL"
+    INFORME_RENDIMENTOS = "INFORME_RENDIMENTOS"
+    DASN_SIMEI = "DASN_SIMEI"
+    RECIBO_IR_ANTERIOR = "RECIBO_IR_ANTERIOR"
+    DOC_IDENTIFICACAO = "DOC_IDENTIFICACAO"
+    COMPROVANTE_ENDERECO = "COMPROVANTE_ENDERECO"
 
 
 class DocumentJob(BaseModel):
@@ -21,7 +33,8 @@ class DocumentJob(BaseModel):
     id: uuid.UUID = Field(default_factory=uuid.uuid4)
     user_id: uuid.UUID
     file_path: str  # Path in the object storage
-    status: ProcessingStatus = ProcessingStatus.PENDING
+    document_type: DocumentType
+    status: ProcessingStatus = ProcessingStatus.PROCESSING
     extracted_data: Optional[Dict[str, Any]] = None
     error_message: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/services/document_service/application/ports/input/document_service.py
+++ b/backend/services/document_service/application/ports/input/document_service.py
@@ -3,6 +3,7 @@ from typing import IO, List
 import uuid
 
 from shared.models.base_models import DocumentJob as DocumentJobResponse
+from services.document_service.application.domain.document_job import DocumentType
 
 
 class DocumentService(ABC):
@@ -10,7 +11,11 @@ class DocumentService(ABC):
 
     @abstractmethod
     def start_document_processing(
-        self, user_id: uuid.UUID, file_name: str, file_content: IO[bytes]
+        self,
+        user_id: uuid.UUID,
+        file_name: str,
+        file_content: IO[bytes],
+        document_type: DocumentType,
     ) -> DocumentJobResponse:
         """
         Use case for uploading a document and starting the processing workflow.

--- a/backend/services/document_service/infrastructure/adapters/persistence/postgres_document_job_repository.py
+++ b/backend/services/document_service/infrastructure/adapters/persistence/postgres_document_job_repository.py
@@ -24,6 +24,7 @@ class PostgresDocumentJobRepository(DocumentJobRepository):
             self.db.add(job_model)
         else:
             job_model.status = job.status
+            job_model.document_type = job.document_type
             job_model.extracted_data = job.extracted_data
             job_model.error_message = job.error_message
 

--- a/backend/services/document_service/infrastructure/database.py
+++ b/backend/services/document_service/infrastructure/database.py
@@ -5,7 +5,7 @@ from sqlalchemy.ext.declarative import declarative_base
 import uuid
 from datetime import datetime
 
-from ..application.domain.document_job import ProcessingStatus
+from ..application.domain.document_job import DocumentType, ProcessingStatus
 from .config import settings
 
 engine = create_engine(settings.DATABASE_URL)
@@ -20,8 +20,9 @@ class DocumentJobModel(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id = Column(UUID(as_uuid=True), nullable=False, index=True)
     file_path = Column(String, nullable=False)
+    document_type = Column(Enum(DocumentType), nullable=False)
     status = Column(
-        Enum(ProcessingStatus), nullable=False, default=ProcessingStatus.PENDING
+        Enum(ProcessingStatus), nullable=False, default=ProcessingStatus.PROCESSING
     )
     extracted_data = Column(JSONB)
     error_message = Column(String)

--- a/backend/shared/database/database_schemas.sql
+++ b/backend/shared/database/database_schemas.sql
@@ -44,13 +44,25 @@ CREATE TABLE IF NOT EXISTS knowledge_base (
 );
 
 -- Tabela de Documentos / Jobs de Processamento (Document Service)
-CREATE TYPE processing_status AS ENUM ('''PENDING''', '''PROCESSING''', '''COMPLETED''', '''FAILED''');
+CREATE TYPE processing_status AS ENUM ('''pendente''', '''processando''', '''concluido''', '''falhou''');
+CREATE TYPE document_type AS ENUM (
+    '''NOTA_FISCAL_EMITIDA''',
+    '''NOTA_FISCAL_RECEBIDA''',
+    '''INFORME_BANCARIO''',
+    '''DESPESA_DEDUTIVEL''',
+    '''INFORME_RENDIMENTOS''',
+    '''DASN_SIMEI''',
+    '''RECIBO_IR_ANTERIOR''',
+    '''DOC_IDENTIFICACAO''',
+    '''COMPROVANTE_ENDERECO'''
+);
 
 CREATE TABLE IF NOT EXISTS document_processing_jobs (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     file_path VARCHAR(1024) NOT NULL, -- Caminho no MinIO
-    status processing_status NOT NULL DEFAULT '''PENDING''',
+    document_type document_type NOT NULL,
+    status processing_status NOT NULL DEFAULT '''processando''',
     extracted_data JSONB,
     error_message TEXT,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,

--- a/backend/shared/models/base_models.py
+++ b/backend/shared/models/base_models.py
@@ -11,10 +11,22 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 
 class ProcessingStatus(str, Enum):
-    PENDING = "PENDING"
-    PROCESSING = "PROCESSING"
-    COMPLETED = "COMPLETED"
-    FAILED = "FAILED"
+    PENDING = "pendente"
+    PROCESSING = "processando"
+    COMPLETED = "concluido"
+    FAILED = "falhou"
+
+
+class DocumentType(str, Enum):
+    NOTA_FISCAL_EMITIDA = "NOTA_FISCAL_EMITIDA"
+    NOTA_FISCAL_RECEBIDA = "NOTA_FISCAL_RECEBIDA"
+    INFORME_BANCARIO = "INFORME_BANCARIO"
+    DESPESA_DEDUTIVEL = "DESPESA_DEDUTIVEL"
+    INFORME_RENDIMENTOS = "INFORME_RENDIMENTOS"
+    DASN_SIMEI = "DASN_SIMEI"
+    RECIBO_IR_ANTERIOR = "RECIBO_IR_ANTERIOR"
+    DOC_IDENTIFICACAO = "DOC_IDENTIFICACAO"
+    COMPROVANTE_ENDERECO = "COMPROVANTE_ENDERECO"
 
 
 class TransactionType(str, Enum):
@@ -91,6 +103,7 @@ class DocumentJob(BaseModel):
     id: uuid.UUID
     user_id: uuid.UUID
     file_path: str
+    document_type: DocumentType
     status: ProcessingStatus
     extracted_data: Optional[Dict[str, Any]] = None
     error_message: Optional[str] = None


### PR DESCRIPTION
## Summary
- add document type metadata and Portuguese processing statuses to document job models
- require a document type on the upload endpoint, validate supported file formats, and propagate the new metadata through the service
- extend persistence and documentation to capture the new document type column and status defaults

## Testing
- pytest backend/tests/unit/test_document_service.py *(fails: missing email-validator dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691463dc70188322805e8fa21a49d00a)