### PR TITLE
Fix nested amount extraction in financial summary builder

### DIFF
--- a/services/agent/app/services/financial_summary.py
+++ b/services/agent/app/services/financial_summary.py
@@ -110,16 +110,26 @@ class FinancialSummaryBuilder:
             for item in payload:
                 if isinstance(item, dict):
                     values.extend(self._extract_values(item))
+                elif isinstance(item, list):
+                    values.extend(self._extract_values(item))
+                else:
+                    amount = _coerce_amount(item)
+                    if amount is not None:
+                        values.append(amount)
             return values
 
         if isinstance(payload, dict):
             values = []
             for key, value in payload.items():
-                normalized_key = _normalize_key(key)
+                normalized_key = _normalize_key(str(key))
                 if any(fragment in normalized_key for fragment in ["valor", "total", "montante", "quantia"]):
                     amount = _coerce_amount(value)
                     if amount is not None:
                         values.append(amount)
+                    elif isinstance(value, (dict, list)):
+                        values.extend(self._extract_values(value))
+                elif isinstance(value, (dict, list)):
+                    values.extend(self._extract_values(value))
             return values
 
         if isinstance(payload, (int, float)):


### PR DESCRIPTION
## Summary
- add vector-enabled storage and retrieval for user document chunks
- aggregate MEI revenues, expenses, and DASN-SIMEI data when composing responses
- expose FastAPI chat endpoint backed by deterministic embeddings and cite context
- cover aggregation and chat orchestration with unit tests
- fix `_extract_values` recursion so nested amounts in MEI documents are aggregated

## Testing
- python -m unittest discover services/agent/tests

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914980a97f48322abf4da5359fe83dc)