### PR TITLE
Normaliza chaves não textuais na extração de valores financeiros

### DIFF
--- a/services/agent/app/services/financial_summary.py
+++ b/services/agent/app/services/financial_summary.py
@@ -110,16 +110,26 @@ class FinancialSummaryBuilder:
             for item in payload:
                 if isinstance(item, dict):
                     values.extend(self._extract_values(item))
+                elif isinstance(item, list):
+                    values.extend(self._extract_values(item))
+                else:
+                    amount = _coerce_amount(item)
+                    if amount is not None:
+                        values.append(amount)
             return values
 
         if isinstance(payload, dict):
             values = []
             for key, value in payload.items():
-                normalized_key = _normalize_key(key)
+                normalized_key = _normalize_key(str(key))
                 if any(fragment in normalized_key for fragment in ["valor", "total", "montante", "quantia"]):
                     amount = _coerce_amount(value)
                     if amount is not None:
                         values.append(amount)
+                    elif isinstance(value, (dict, list)):
+                        values.extend(self._extract_values(value))
+                elif isinstance(value, (dict, list)):
+                    values.extend(self._extract_values(value))
             return values
 
         if isinstance(payload, (int, float)):


### PR DESCRIPTION
FinancialSummaryBuilder._extract_values

Tratamento de payloads dict

Converte a chave para str antes de chamar _normalize_key

normalized_key = _normalize_key(str(key))

Garante que campos cujo nome contenha:

"valor"

"total"

"montante"

"quantia"
sejam corretamente reconhecidos mesmo quando a chave não vier como str (ex.: int, Enum, etc.)

Mantém a recursão para valores do tipo dict ou list inalterada

Impacto

Aumenta a robustez da extração de receitas e despesas em payloads heterogêneos (OCR/JSON com chaves tipadas)

Não altera o comportamento para chaves que já eram strings