### PR TITLE
Add Raspberry Pi VM provisioning workflow

### DIFF
--- a/infra/provision_vm.sh
+++ b/infra/provision_vm.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Provisiona uma VM Debian/Ubuntu minimal em Raspberry Pi para hospedar o homelab.
+# Executar como root logo após instalar o SO base.
+set -euo pipefail
+
+HOMELAB_USER="homelab"
+SSH_PUBLIC_KEY="${HOMELAB_PUBLIC_KEY:-}"
+SSH_PUBLIC_KEY_FILE="${HOMELAB_PUBLIC_KEY_FILE:-}"
+REQUIRED_PACKAGES=(
+  openssh-server
+  sudo
+  curl
+  ca-certificates
+  unattended-upgrades
+  fail2ban
+  ufw
+)
+
+error() {
+  echo "[erro] $*" >&2
+  exit 1
+}
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    error "Execute como root (sudo)."
+  fi
+}
+
+validate_os() {
+  if [[ ! -f /etc/os-release ]]; then
+    error "Arquivo /etc/os-release não encontrado; SO não suportado."
+  fi
+  source /etc/os-release
+  case "$ID" in
+    ubuntu|debian|raspbian)
+      echo "[ok] SO suportado: ${PRETTY_NAME}"
+      ;;
+    *)
+      error "SO ${PRETTY_NAME:-$ID} não suportado. Use Debian/Ubuntu."
+      ;;
+  esac
+}
+
+resolve_public_key() {
+  if [[ -n "$SSH_PUBLIC_KEY" ]]; then
+    echo "$SSH_PUBLIC_KEY"
+    return
+  fi
+
+  if [[ -n "$SSH_PUBLIC_KEY_FILE" ]]; then
+    if [[ ! -f "$SSH_PUBLIC_KEY_FILE" ]]; then
+      error "Arquivo de chave pública não encontrado em $SSH_PUBLIC_KEY_FILE"
+    fi
+    cat "$SSH_PUBLIC_KEY_FILE"
+    return
+  fi
+
+  local default_key="$HOME/.ssh/id_rsa.pub"
+  if [[ -f "$default_key" ]]; then
+    cat "$default_key"
+    return
+  fi
+
+  error "Forneça HOMELAB_PUBLIC_KEY ou HOMELAB_PUBLIC_KEY_FILE com a chave pública."
+}
+
+configure_user() {
+  local pubkey="$1"
+  if id "$HOMELAB_USER" &>/dev/null; then
+    echo "[ok] Usuário $HOMELAB_USER já existe"
+  else
+    adduser --disabled-password --gecos "Homelab Admin" "$HOMELAB_USER"
+    usermod -aG sudo "$HOMELAB_USER"
+    echo "[ok] Usuário $HOMELAB_USER criado e adicionado ao sudo"
+  fi
+
+  local ssh_dir="/home/${HOMELAB_USER}/.ssh"
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+  echo "$pubkey" >"${ssh_dir}/authorized_keys"
+  chmod 600 "${ssh_dir}/authorized_keys"
+  chown -R "$HOMELAB_USER:$HOMELAB_USER" "$ssh_dir"
+  echo "[ok] Chave pública instalada em ${ssh_dir}/authorized_keys"
+}
+
+install_packages() {
+  echo "[info] Atualizando lista de pacotes..."
+  apt-get update -y
+  echo "[info] Instalando pacotes essenciais: ${REQUIRED_PACKAGES[*]}"
+  apt-get install -y "${REQUIRED_PACKAGES[@]}"
+}
+
+configure_ssh() {
+  mkdir -p /etc/ssh/sshd_config.d
+  cat >/etc/ssh/sshd_config.d/10-homelab.conf <<'CFG'
+# Endurecimento mínimo para acesso por chave
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+PermitRootLogin no
+PubkeyAuthentication yes
+CFG
+  systemctl enable ssh
+  systemctl restart ssh
+  echo "[ok] SSH configurado para recusar senha e desabilitar login de root"
+}
+
+configure_unattended_upgrades() {
+  cat >/etc/apt/apt.conf.d/20auto-upgrades <<'CFG'
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+CFG
+
+  cat >/etc/apt/apt.conf.d/51unattended-upgrades-homelab <<'CFG'
+Unattended-Upgrade::Allowed-Origins {
+        "${distro_id}:${distro_codename}";
+        "${distro_id}:${distro_codename}-security";
+        "${distro_id}ESM:${distro_codename}";
+        "Debian:${distro_codename}-security";
+};
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "03:00";
+CFG
+
+  systemctl enable unattended-upgrades
+  systemctl restart unattended-upgrades || true
+  echo "[ok] Atualizações automáticas de segurança habilitadas"
+}
+
+configure_firewall() {
+  if command -v ufw >/dev/null 2>&1; then
+    ufw allow OpenSSH
+    ufw --force enable
+    echo "[ok] UFW habilitado permitindo apenas SSH por padrão"
+  fi
+}
+
+main() {
+  require_root
+  validate_os
+  local pubkey
+  pubkey=$(resolve_public_key)
+  install_packages
+  configure_user "$pubkey"
+  configure_ssh
+  configure_unattended_upgrades
+  configure_firewall
+  echo "[sucesso] Provisionamento concluído. Conecte-se via SSH como ${HOMELAB_USER}."
+}
+
+main "$@"

--- a/infra/validate_vm.py
+++ b/infra/validate_vm.py
@@ -1,0 +1,108 @@
+"""Validador do provisionamento da VM Linux para o homelab.
+
+Executa verificações locais para garantir que:
+- O SO é Debian/Ubuntu (ou variante Raspberry Pi) suportado.
+- Pacotes essenciais estão instalados.
+- O SSH está configurado para recusar autenticação por senha.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+SUPPORTED_OS = {"ubuntu", "debian", "raspbian"}
+REQUIRED_PACKAGES = [
+    "openssh-server",
+    "sudo",
+    "unattended-upgrades",
+    "ca-certificates",
+]
+
+
+class ValidationError(RuntimeError):
+    """Erro quando um requisito não é atendido."""
+
+
+def parse_os_release(path: Path = Path("/etc/os-release")) -> Tuple[str, str]:
+    if not path.exists():
+        raise ValidationError("/etc/os-release não encontrado")
+
+    os_id = ""
+    pretty = ""
+    for line in path.read_text().splitlines():
+        if line.startswith("ID="):
+            os_id = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("PRETTY_NAME="):
+            pretty = line.split("=", 1)[1].strip().strip('"')
+
+    if not os_id:
+        raise ValidationError("ID do SO não encontrado em /etc/os-release")
+    return os_id, pretty or os_id
+
+
+def check_supported_os(path: Path = Path("/etc/os-release")) -> str:
+    os_id, pretty = parse_os_release(path)
+    if os_id not in SUPPORTED_OS:
+        raise ValidationError(f"SO {pretty} não é suportado; use Debian/Ubuntu.")
+    return pretty
+
+
+def check_packages(packages: Iterable[str] = REQUIRED_PACKAGES) -> List[str]:
+    missing: List[str] = []
+    for package in packages:
+        result = subprocess.run(
+            ["dpkg-query", "-W", "-f", "${Status}", package],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if "install ok installed" not in result.stdout:
+            missing.append(package)
+    if missing:
+        raise ValidationError(f"Pacotes ausentes: {', '.join(missing)}")
+    return list(packages)
+
+
+def _collect_sshd_configs(sshd_config: Path, sshd_config_d: Path) -> str:
+    contents = []
+    if sshd_config.exists():
+        contents.append(sshd_config.read_text())
+    if sshd_config_d.exists():
+        for path in sorted(sshd_config_d.glob("*.conf")):
+            contents.append(path.read_text())
+    return "\n".join(contents)
+
+
+def check_ssh_password_disabled(
+    sshd_config: Path = Path("/etc/ssh/sshd_config"),
+    sshd_config_d: Path = Path("/etc/ssh/sshd_config.d"),
+) -> None:
+    text = _collect_sshd_configs(sshd_config, sshd_config_d)
+    lowered = text.lower()
+    if "passwordauthentication no" not in lowered:
+        raise ValidationError("PasswordAuthentication não está configurado como 'no'")
+    if "permitrootlogin no" not in lowered:
+        raise ValidationError("PermitRootLogin não está configurado como 'no'")
+
+
+def main() -> int:
+    try:
+        pretty = check_supported_os()
+        print(f"[ok] SO suportado: {pretty}")
+
+        installed = check_packages()
+        print(f"[ok] Pacotes encontrados: {', '.join(installed)}")
+
+        check_ssh_password_disabled()
+        print("[ok] SSH configurado para recusar senha e login de root")
+
+    except ValidationError as exc:  # pragma: no cover - fluxo de erro controlado
+        print(f"[erro] {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - chamado direto
+    raise SystemExit(main())

--- a/tests/infra/test_validate_vm.py
+++ b/tests/infra/test_validate_vm.py
@@ -1,0 +1,60 @@
+"""Testes de unidade para o validador de provisionamento de VM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from infra import validate_vm
+
+
+def test_parse_os_release_reads_id_and_pretty(tmp_path: Path) -> None:
+    content = "\n".join([
+        "NAME=Ubuntu",
+        "ID=ubuntu",
+        "PRETTY_NAME=\"Ubuntu 22.04.3 LTS\"",
+    ])
+    path = tmp_path / "os-release"
+    path.write_text(content)
+
+    os_id, pretty = validate_vm.parse_os_release(path)
+
+    assert os_id == "ubuntu"
+    assert pretty == "Ubuntu 22.04.3 LTS"
+
+
+def test_check_supported_os_rejects_unknown(tmp_path: Path) -> None:
+    path = tmp_path / "os-release"
+    path.write_text("ID=arch\nPRETTY_NAME=\"Arch Linux\"")
+
+    with pytest.raises(validate_vm.ValidationError):
+        validate_vm.check_supported_os(path)
+
+
+def test_check_packages_reports_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeCompletedProcess:
+        def __init__(self, stdout: str):
+            self.stdout = stdout
+
+    def fake_run(cmd, capture_output, text, check):  # type: ignore[no-untyped-def]
+        package = cmd[-1]
+        stdout = "Status: install ok installed" if package != "sudo" else "Status: install ok not-installed"
+        return FakeCompletedProcess(stdout=stdout)
+
+    monkeypatch.setattr(validate_vm.subprocess, "run", fake_run)
+
+    with pytest.raises(validate_vm.ValidationError) as excinfo:
+        validate_vm.check_packages(["openssh-server", "sudo"])
+
+    assert "sudo" in str(excinfo.value)
+
+
+def test_check_ssh_password_disabled_reads_conf(tmp_path: Path) -> None:
+    main_conf = tmp_path / "sshd_config"
+    main_conf.write_text("PasswordAuthentication no\n")
+    conf_d = tmp_path / "sshd_config.d"
+    conf_d.mkdir()
+    (conf_d / "10-homelab.conf").write_text("PermitRootLogin no\n")
+
+    validate_vm.check_ssh_password_disabled(main_conf, conf_d)


### PR DESCRIPTION
## Summary
- add provisioning shell script to harden Raspberry Pi Debian/Ubuntu hosts for the homelab
- provide validation utility to confirm OS, packages, and SSH hardening
- cover validator logic with unit tests for OS parsing, package detection, and SSH settings

## Testing
- pytest tests/infra/test_validate_vm.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69246190f9c88322b0a30d7880361334)